### PR TITLE
Generic goto_link

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -33,7 +33,7 @@ async fn get_game(team: mlb::teams::Team) -> Option<LiveGame> {
             .first()?
             .games
             .first()?
-            .goto_link::<LiveGame>()
+            .goto_link()
             .await
             .ok()
     } else {

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -39,9 +39,9 @@ where
 }
 
 #[async_trait]
-pub trait GetLink {
+pub trait GetLink<T> {
     fn get_link(&self) -> &str;
-    async fn goto_link<T>(&self) -> Result<T>
+    async fn goto_link(&self) -> Result<T>
     where
         T: DeserializeOwned,
     {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -155,7 +155,7 @@ pub async fn get_schedule<T: std::string::ToString>(team_id: T) -> Result<Schedu
     .await
 }
 
-impl GetLink for Game {
+impl GetLink<crate::live::LiveGame> for Game {
     fn get_link(&self) -> &str {
         &self.link
     }

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::requests::{get, GetLink};
+use crate::requests::get;
 
 #[derive(Serialize, Deserialize)]
 pub struct Teams {
@@ -21,9 +21,6 @@ pub struct Team {
 
     #[serde(rename = "name")]
     pub name: String,
-
-    #[serde(rename = "link")]
-    pub link: String,
 
     #[serde(rename = "league")]
     pub league: League,
@@ -56,12 +53,6 @@ pub struct League {
 impl Teams {
     pub async fn get_teams() -> Result<Teams> {
         get("teams").await
-    }
-}
-
-impl GetLink for Team {
-    fn get_link(&self) -> &str {
-        &self.link
     }
 }
 


### PR DESCRIPTION
As a result, goto_link is no longer generic, as it will always resolve to an `Option` of the type specified in GetLink.