### PR TITLE
Bump tabled to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ clap = "2.33.3"
 reqwest = {version = "0.11.4", features = ["json", "blocking"]}
 serde = {version = "1.0.130", features = ["derive"]}
 serde_json = "1.0.68"
-tabled = "0.3.0"
+tabled = "0.5.0"
 async-trait = {version = "0.1.51"}
 tokio = {version = "1.12.0", features = ["rt-multi-thread", "macros"]}
 chrono = {version = "0.4.19", features = ["serde"]}

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -50,7 +50,7 @@ async fn scores(team_name: Option<&str>) -> Result<()> {
             if let Some(score) = game.get_score() {
                 println!(
                     "{}{} {}",
-                    Table::new([score.away, score.home]).with(Style::pseudo()),
+                    Table::new([score.away, score.home]).with(Style::modern()),
                     score.inning_state,
                     score.inning
                 );


### PR DESCRIPTION
Update dependency [tabled](https://crates.io/crates/tabled) from version 0.3.0 to version 0.5.0. This removes the `Psuedo` style, so now use `Modern` style instead