### PR TITLE
Add link type to simplify links

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -27,7 +27,15 @@ fn is_in_league(team: &mlb::teams::Team) -> bool {
 // TODO: Make this return a vector of games to properly handle doubleheaders.
 async fn get_game(team: mlb::teams::Team) -> Option<LiveGame> {
     let schedule = mlb::schedule::get_schedule(team.id).await.ok()?;
-    schedule.dates.first()?.games.first()?.get_game().await.ok()
+    schedule
+        .dates
+        .first()?
+        .games
+        .first()?
+        .link
+        .follow()
+        .await
+        .ok()
 }
 
 async fn scores(team_name: Option<&str>) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@ pub mod requests;
 pub mod schedule;
 pub mod teams;
 
+pub mod link;
 pub mod live;

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,0 +1,21 @@
+use std::marker::PhantomData;
+
+use crate::requests::Request;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Link<T: for<'d> Deserialize<'d>> {
+    _phantom: PhantomData<T>,
+    link: String,
+}
+
+impl<T: for<'de> Deserialize<'de>> Link<T> {
+    pub async fn follow(&self) -> Result<T> {
+        Request::new()
+            .with_api("")
+            .with_endpoint(self.link.as_str())
+            .get()
+            .await
+    }
+}

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use crate::{live::LiveGame, requests::Request};
+use crate::{link::Link, live::LiveGame, requests::Request};
 
 #[derive(Serialize, Deserialize)]
 pub struct Schedule {
@@ -57,7 +57,7 @@ pub struct Game {
     pub game_pk: i64,
 
     #[serde(rename = "link")]
-    pub link: String,
+    pub link: Link<LiveGame>,
 
     #[serde(rename = "teams")]
     pub teams: Teams,
@@ -70,12 +70,6 @@ pub struct Game {
 
     #[serde(rename = "scheduledInnings")]
     pub scheduled_innings: i64,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub struct Content {
-    #[serde(rename = "link")]
-    pub link: String,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -142,9 +136,6 @@ pub struct Venue {
 
     #[serde(rename = "name")]
     pub name: String,
-
-    #[serde(rename = "link")]
-    pub link: String,
 }
 
 pub async fn get_schedule<T: std::string::ToString>(team_id: T) -> Result<Schedule> {
@@ -153,14 +144,4 @@ pub async fn get_schedule<T: std::string::ToString>(team_id: T) -> Result<Schedu
         .with_params([("sportId", "1"), ("teamId", &team_id.to_string())])
         .get()
         .await
-}
-
-impl Game {
-    pub async fn get_game(&self) -> Result<LiveGame> {
-        Request::new()
-            .with_api("")
-            .with_endpoint(self.link.as_str())
-            .get()
-            .await
-    }
 }


### PR DESCRIPTION
Currently everything is handled through strings, but this can/should be done in a smarter way by marking the type the link points to.